### PR TITLE
Implement inductive types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1430%20SLOC-blue)](rooster_kernel/src/lib.rs)
+[![Kernel size](https://img.shields.io/badge/kernel-1394%20SLOC-blue)](rooster_kernel/src/lib.rs)
 
 An automated proof checker based on the Calculus of Constructions.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1363%20SLOC-blue)](rooster_kernel/src/lib.rs)
+[![Kernel size](https://img.shields.io/badge/kernel-1430%20SLOC-blue)](rooster_kernel/src/lib.rs)
 
 An automated proof checker based on the Calculus of Constructions.
 
@@ -43,6 +43,14 @@ disjunction_of_implication_is_commutative = λA:Prop.λB:Prop.disjunction_is_com
     :∀A:Prop.∀B:Prop.(∀$465:Prop.((A→B)→$465)→((B→A)→$465)→$465)→∀$474:Prop.((B→A)→$474)→((A→B)→$474)→$474
 equivalence_implies_implication = λA:Prop.λB:Prop.conjunction_implies_operand A→B B→A
     :∀A:Prop.∀B:Prop.(∀$494:Prop.((A→B)→(B→A)→$494)→$494)→A→B
+nat = 𝐘self:Set.∀T:?.T→(self→T)→T
+    :Set
+O = λT:? nat.λa:T.λb:nat→T.a
+    :nat
+S = λx:nat.λT:? nat.λa:T.λb:nat→T.b x
+    :nat→nat
+add = 𝐘self:nat→nat→nat.λn:nat.λm:nat.n nat m λp:nat.S (self p m
+    :nat→nat→nat
 ```
 
 ## Features
@@ -58,7 +66,7 @@ Syntax extensions:
 | CoC terms | `A(B)` `\|x: A\| B` `@(x: A) B` `Prop` `Type(n)` `{A}` |
 | CoC sentences | `let a: A = B;` |
 | Intuitionistic logic | `A -> B` `False` `^A` `A /\ B` `A \/ B` `exists(x: A) B` `A <-> B` |
-| Inductive types | `?` `recursive(x:A) B` `Set` |
+| Inductive types | `?` `recursive(x: A) B` `Set` |
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1253%20SLOC-blue)](rooster_kernel/src/lib.rs)
+[![Kernel size](https://img.shields.io/badge/kernel-1368%20SLOC-blue)](rooster_kernel/src/lib.rs)
 
 An automated proof checker based on the Calculus of Constructions.
 
@@ -43,7 +43,7 @@ disjunction_of_implication_is_commutative = λA:Prop.λB:Prop.disjunction_is_com
     :∀A:Prop.∀B:Prop.(∀$465:Prop.((A→B)→$465)→((B→A)→$465)→$465)→∀$474:Prop.((B→A)→$474)→((A→B)→$474)→$474
 equivalence_implies_implication = λA:Prop.λB:Prop.conjunction_implies_operand A→B B→A
     :∀A:Prop.∀B:Prop.(∀$494:Prop.((A→B)→(B→A)→$494)→$494)→A→B
-nat = 𝐘self:Set.∀T:?.T→(self→T)→T
+nat = 𝐘self:Set.∀T:? Set.T→(self→T)→T
     :Set
 O = λT:? nat.λa:T.λb:nat→T.a
     :nat
@@ -51,6 +51,8 @@ S = λx:nat.λT:? nat.λa:T.λb:nat→T.b x
     :nat→nat
 add = 𝐘self:nat→nat→nat.λn:nat.λm:nat.n nat m λp:nat.S (self p m
     :nat→nat→nat
+nat_inductive_hypothesis = 𝐘self:∀P:nat→Prop.P O→(∀n:nat.P n→P (S n)→∀n:nat.P n.λP:nat→Prop.λpO:P O.λh:∀n:nat.P n→P (S n.λn:nat.n (P n pO λp:nat.h p (self P pO h p
+    :∀P:nat→Prop.P O→(∀n:nat.P n→P (S n)→∀n:nat.P n
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-703%20SLOC-blue)](rooster_kernel/src/lib.rs)
+[![Kernel size](https://img.shields.io/badge/kernel-1363%20SLOC-blue)](rooster_kernel/src/lib.rs)
 
 An automated proof checker based on the Calculus of Constructions.
 
@@ -48,6 +48,7 @@ equivalence_implies_implication = λA:Prop.λB:Prop.conjunction_implies_operand 
 ## Features
 Core language:
  - [x] Calculus of Constructions
+ - [ ] Inductive types (_WIP_)
 
 Syntax extensions:
  - [x] Intuitionistic logic

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1394%20SLOC-blue)](rooster_kernel/src/lib.rs)
+[![Kernel size](https://img.shields.io/badge/kernel-1253%20SLOC-blue)](rooster_kernel/src/lib.rs)
 
 An automated proof checker based on the Calculus of Constructions.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Syntax extensions:
 | CoC terms | `A(B)` `\|x: A\| B` `@(x: A) B` `Prop` `Type(n)` `{A}` |
 | CoC sentences | `let a: A = B;` |
 | Intuitionistic logic | `A -> B` `False` `^A` `A /\ B` `A \/ B` `exists(x: A) B` `A <-> B` |
+| Inductive types | `?` `recursive(x:A) B` `Set` |
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Rooster
 [![Kernel size](https://img.shields.io/badge/kernel-1368%20SLOC-blue)](rooster_kernel/src/lib.rs)
 
-An automated proof checker based on the Calculus of Constructions.
+An automated proof checker based on the Calculus of Constructions
+plus inductive types.
 
 Written in Rust, proofs also employ a Rust-like syntax.
 At the moment, it doesn't have many features, but it does work.
@@ -58,7 +59,7 @@ nat_inductive_hypothesis = 𝐘self:∀P:nat→Prop.P O→(∀n:nat.P n→P (S n
 ## Features
 Core language:
  - [x] Calculus of Constructions
- - [ ] Inductive types (_WIP_)
+ - [x] Inductive types
 
 Syntax extensions:
  - [x] Intuitionistic logic

--- a/rooster/Cargo.toml
+++ b/rooster/Cargo.toml
@@ -18,7 +18,7 @@ chumsky = "0.9.0"
 
 [package.metadata.bundle]
 name = "Rooster"
-identifier = "ioo.github.aerkiaga.rooster"
+identifier = "io.github.aerkiaga.rooster"
 version = "0.1.0"
 copyright = "Copyright (c) Aritz Erkiaga Fernández 2023. Distributed under the GNU GPL license, version 3.0."
 category = "Development"

--- a/rooster/src/ast.rs
+++ b/rooster/src/ast.rs
@@ -23,6 +23,11 @@ pub enum Expression {
         value_expression: Box<Expression>,
         span: (usize, usize),
     },
+    FixedPoint {
+        binding: Binding,
+        value_expression: Box<Expression>,
+        span: (usize, usize),
+    },
 }
 
 impl Expression {
@@ -40,6 +45,11 @@ impl Expression {
                 span,
             } => *span,
             Self::Forall {
+                binding: _,
+                value_expression: _,
+                span,
+            } => *span,
+            Self::FixedPoint {
                 binding: _,
                 value_expression: _,
                 span,

--- a/rooster/src/diagnostics.rs
+++ b/rooster/src/diagnostics.rs
@@ -191,5 +191,6 @@ pub fn emit_kernel_diagnostic(error: &KernelError, code: &String, source_id: &St
                 .print((source_id, Source::from(code)))
                 .unwrap();
         }
+        _ => panic!("Unhandled kernel error"),
     }
 }

--- a/rooster/src/diagnostics.rs
+++ b/rooster/src/diagnostics.rs
@@ -191,6 +191,29 @@ pub fn emit_kernel_diagnostic(error: &KernelError, code: &String, source_id: &St
                 .print((source_id, Source::from(code)))
                 .unwrap();
         }
-        _ => panic!("Unhandled kernel error"),
+        KernelError::MisshapenInductiveDefinition {
+            unexpected_subterm,
+            subterm_context,
+            full_term_context,
+        } => {
+            println!("MisshapenInductiveDefinition");
+        }
+        KernelError::NegativeInductiveDefinition {
+            negative_subterm,
+            subterm_context,
+            full_term_context,
+        } => {
+            println!("NegativeInductiveDefinition");
+        }
+        KernelError::MisshapenRecursiveDefinition {
+            unexpected_subterm,
+            subterm_context,
+            full_term_context,
+        } => {
+            println!("MisshapenRecursiveDefinition");
+        }
+        KernelError::NonprimitiveRecursiveFunction { full_term_context } => {
+            println!("NonprimitiveRecursiveFunction");
+        }
     }
 }

--- a/rooster/src/kernel.rs
+++ b/rooster/src/kernel.rs
@@ -35,6 +35,16 @@ pub fn new_term(expression: &Expression) -> Term {
             value_term: Box::new(new_term(value_expression)),
             debug_context: TermDebugContext::CodeSpan(*span),
         },
+        Expression::FixedPoint {
+            binding,
+            value_expression,
+            span,
+        } => Term::FixedPoint {
+            binding_identifier: binding.identifier.clone(),
+            binding_type: Box::new(new_term(&binding.type_expression)),
+            value_term: Box::new(new_term(value_expression)),
+            debug_context: TermDebugContext::CodeSpan(*span),
+        },
     }
 }
 

--- a/rooster_kernel/src/lib.rs
+++ b/rooster_kernel/src/lib.rs
@@ -1,5 +1,6 @@
 //! This crate contains **Rooster**'s proof kernel code,
-//! an implementation of the [Calculus of Constructions](https://en.wikipedia.org/wiki/Calculus_of_constructions) (CoC).
+//! an implementation of the [Calculus of Constructions](https://en.wikipedia.org/wiki/Calculus_of_constructions) (CoC)
+//! with inductive types.
 //!
 //! CoC is a mathematical type theory and programming language
 //! developed by adding dependent types, polymorphism and

--- a/rooster_kernel/src/lib.rs
+++ b/rooster_kernel/src/lib.rs
@@ -124,27 +124,60 @@
 //! * ? has type ?.
 //! * ∀x:A.B takes the type of B, with each free occurrence
 //! of 'x' within B taking type A.
-//!   - If A equals ?, however, the term takes type Set.
-//!     * In this case, occurrences of x must be at
-//!       strictly positive positions within B.
+//!   - If A is of the form ? G, then the term follows the
+//!     rules for **inductive types**.
 //! * λx:A.B takes type ∀x:A.T, with T being the type of B
 //! with each free occurrence of 'x' within B taking type A.
+//!   - If A is of the form ? I, then the term follows the
+//!     rules for **inductive instances**.
 //! * A B, where A has type ∀x:T.V, takes type V[x:=B].
 //!   - If A doesn't have such type, the term is invalid.
 //!   - If B is not of type T, the term is invalid.
 //!     * This does not apply if T equals ?.
-//! * 𝐘x:A.B takes type B, with each free occurrence
-//! of 'x' within B taking type A.
-//!   - B can be an expression of the form ∀x1:A1.∀x2:A2. ... C
-//!     wherein each An only contains x strictly positively
-//!     and C doesn't freely contain x.
-//!   - B can also be an expression of the form λx1:A1.λx2:A2. ... C
-//!     wherein every occurrence of x in C reduces to
-//!     x y1 y2 ... and there is at least some i such that
-//!     every yi is captured by an abstraction passed to
-//!     xi, which type's type is Set.
-//!   - If B doesn't follow the above, the term is invalid.
+//! * 𝐘x:A.B takes type A, provided that B is also of type A.
+//!   Additionally, either of the following rules must apply:
+//!   - B, and thus 𝐘x:A.B, fulfills the rules for **inductive types**.
+//!   - 𝐘x:A.B fulfills the rules for **primitive recursive functions**.
 //!
+//! ### Inductive types
+//! An inductive type has the form ∀T:? G.M, or alternatively
+//! 𝐘S:G.∀T:? G.M (i.e., the first form enclosed in a
+//! fixed-point operator).
+//!
+//! Rules for type-checking are the following:
+//! * 'T' only appears _strictly positively_ within M.
+//! * 'S' only appears _strictly positively_ within each
+//!   parameter type of M.
+//!
+//! ∀T:? G.M has type G if it fulfills the criteria
+//! above. 𝐘S:G.B has type G if B also has type G,
+//! otherwise fails to check.
+//!
+//! ### Inductive instances
+//! An instance of an inductive type has the form
+//! λT:? I.M, where I is an inductive type.
+//!
+//! Rules for type-checking are the following:
+//! * M must have type equal to fixed-point-reduced I.
+//!
+//! λT:? I.M has type I if the above holds, otherwise
+//! it fails the type check.
+//!
+//! ### Primitive recursive functions
+//! These are objects of the form 𝐘s:T.F, wherein
+//! F is not an **inductive type**.
+//!
+//! Being F of the form λx1:A1.λx2:A2. ... D, there
+//! must be some i such that Ai is an **inductive
+//! type** and 's' does not occur anywhere within D
+//! _except_ when fulfilling the condition below.
+//!
+//! If a sub-expression within D is of the form
+//! xi P1 P2 P3 ..., and any such Pj is itself
+//! of the form λy1:B1.λy2:B2. ... E, then E
+//! can contain an expression s Q1 Q2 Q3 ...,
+//! provided that Qi (note the i index from above)
+//! is exactly one of the variables in y1, y2, y3 ...
 
 /// A type containing extra information for debugging proofs.
 ///

--- a/test.roo
+++ b/test.roo
@@ -80,5 +80,8 @@ let equivalence_implies_implication:
     conjunction_implies_operand(A -> B, B -> A, h, a)
 ;
 
+// inductive types
+let nat: Set = recursive(self: Set) @(T: ?) T -> {self -> T} -> T;
+
 
 

--- a/test.roo
+++ b/test.roo
@@ -83,5 +83,11 @@ let equivalence_implies_implication:
 // inductive types
 let nat: Set = recursive(self: Set) @(T: ?) T -> {self -> T} -> T;
 
+let O: nat = |T: ?(nat), a: T, b: nat -> T| a;
+let S: nat -> nat = |x: nat| |T: ?(nat), a: T, b: nat -> T| b(x);
+
+let add: nat -> nat -> nat = recursive(self: nat -> nat -> nat) |n, m: nat| n(
+    nat, m, |p: nat| S(self(p, m))
+);
 
 

--- a/test.roo
+++ b/test.roo
@@ -81,7 +81,7 @@ let equivalence_implies_implication:
 ;
 
 // inductive types
-let nat: Set = recursive(self: Set) @(T: ?) T -> {self -> T} -> T;
+let nat: Set = recursive(self: Set) @(T: ?(Set)) T -> {self -> T} -> T;
 
 let O: nat = |T: ?(nat), a: T, b: nat -> T| a;
 let S: nat -> nat = |x: nat| |T: ?(nat), a: T, b: nat -> T| b(x);

--- a/test.roo
+++ b/test.roo
@@ -90,4 +90,16 @@ let add: nat -> nat -> nat = recursive(self: nat -> nat -> nat) |n, m: nat| n(
     nat, m, |p: nat| S(self(p, m))
 );
 
+let nat_inductive_hypothesis: @(P: nat -> Prop)
+    P(O) -> {@(n: nat) P(n) -> P(S(n))} -> @(n: nat) P(n)
+= recursive(self: @(P: nat -> Prop)
+    P(O) -> {@(n: nat) P(n) -> P(S(n))} -> @(n: nat) P(n)
+)
+    |P: nat -> Prop|
+    |pO: P(O)|
+    |h: @(n: nat) P(n) -> P(S(n))|
+    |n: nat|
+    n(P(n), pO, |p: nat| h(p, self(P, pO, h, p)))
+;
+
 


### PR DESCRIPTION
Inductive types are an important extension to the Calculus of Constructions that allow for a lot of new math and the ability to prove new theorems. Notably, they are a key step towards more "classical" computation.

Coq implements them as primitives at the kernel level, in a way that more closely matches the syntax. Meanwhile, the design introduced by this PR deviates from this concept, introducing kernel-level elements that serve to bypass, in a controlled way, the typed restrictions imposed by CoC, making the resulting paradigm behave more like untyped lambda calculus under the devised conditions.

The implementation adds a new `?` identifier that acts as a wilcard for type matching, as well as a `FixedPoint` syntax element that behaves in a way comparable to a fixed-point combinator. However, these powerful elements can only be used in restricted ways, such that consistency is maintaned.

Using these elements, it is possible to build inductive types, use them in expressions and prove propositions about them.