### PR TITLE
Add kernel integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1368%20SLOC-blue)](rooster_kernel/src/lib.rs)
+[![Kernel size](https://img.shields.io/badge/kernel-1369%20SLOC-blue)](rooster_kernel/src/lib.rs)
 
 An automated proof checker based on the Calculus of Constructions
 plus inductive types.
@@ -32,17 +32,17 @@ implication_is_reflexive = λT:Prop.λx:T.x
     :∀T:Prop.T→T
 implication_works = λT:Prop.λP:Prop.λx:T.λy:T→P.y x
     :∀T:Prop.∀P:Prop.T→(T→P)→P
-consequent_always_exists = λT:Prop.λQ:Prop.λh:∀P:Prop.(T→P)→Q.h T λx:T.x
+consequent_always_exists = λT:Prop.λQ:Prop.λh:∀P:Prop.(T→P)→Q.h T (λx:T.x)
     :∀T:Prop.∀$23:Prop.(∀P:Prop.(T→P)→$23)→$23
-conjunction_implies_operand = λA:Prop.λB:Prop.λh:∀P:Prop.(A→B→P)→P.h A λx:A.λy:B.x
+conjunction_implies_operand = λA:Prop.λB:Prop.λh:∀P:Prop.(A→B→P)→P.h A (λx:A.λy:B.x)
     :∀A:Prop.∀B:Prop.(∀$55:Prop.(A→B→$55)→$55)→A
-disjunction_is_commutative = λA:Prop.λB:Prop.λh:∀P:Prop.(A→P)→(B→P)→P.h ∀$233:Prop.(B→$233)→(A→$233)→$233 λa:A.λQ:Prop.λ_:B→Q.λaq:A→Q.aq a λb:B.λQ:Prop.λbq:B→Q.λ_:A→Q.bq b
+disjunction_is_commutative = λA:Prop.λB:Prop.λh:∀P:Prop.(A→P)→(B→P)→P.h (∀$233:Prop.(B→$233)→(A→$233)→$233) (λa:A.λQ:Prop.λ_:B→Q.λaq:A→Q.aq a) (λb:B.λQ:Prop.λbq:B→Q.λ_:A→Q.bq b)
     :∀A:Prop.∀B:Prop.(∀$111:Prop.(A→$111)→(B→$111)→$111)→∀$116:Prop.(B→$116)→(A→$116)→$116
-proposition_and_its_negation_is_false = λA:Prop.λh:∀Q:Prop.(A→(A→⊥)→Q)→Q.h ⊥ λa:A.λnot_a:A→⊥.not_a a
+proposition_and_its_negation_is_false = λA:Prop.λh:∀Q:Prop.(A→(A→⊥)→Q)→Q.h (⊥) (λa:A.λnot_a:A→⊥.not_a a)
     :∀A:Prop.(∀$276:Prop.(A→(A→⊥)→$276)→$276)→⊥
-disjunction_of_implication_is_commutative = λA:Prop.λB:Prop.disjunction_is_commutative A→B B→A
+disjunction_of_implication_is_commutative = λA:Prop.λB:Prop.disjunction_is_commutative (A→B) (B→A)
     :∀A:Prop.∀B:Prop.(∀$465:Prop.((A→B)→$465)→((B→A)→$465)→$465)→∀$474:Prop.((B→A)→$474)→((A→B)→$474)→$474
-equivalence_implies_implication = λA:Prop.λB:Prop.conjunction_implies_operand A→B B→A
+equivalence_implies_implication = λA:Prop.λB:Prop.conjunction_implies_operand (A→B) (B→A)
     :∀A:Prop.∀B:Prop.(∀$494:Prop.((A→B)→(B→A)→$494)→$494)→A→B
 nat = 𝐘self:Set.∀T:? Set.T→(self→T)→T
     :Set
@@ -50,9 +50,9 @@ O = λT:? nat.λa:T.λb:nat→T.a
     :nat
 S = λx:nat.λT:? nat.λa:T.λb:nat→T.b x
     :nat→nat
-add = 𝐘self:nat→nat→nat.λn:nat.λm:nat.n nat m λp:nat.S (self p m)
+add = 𝐘self:nat→nat→nat.λn:nat.λm:nat.n nat m (λp:nat.S (self p m))
     :nat→nat→nat
-nat_inductive_hypothesis = 𝐘self:∀P:nat→Prop.P O→(∀n:nat.P n→P (S n))→∀n:nat.P n.λP:nat→Prop.λpO:P O.λh:∀n:nat.P n→P (S n).λn:nat.n (P n) pO λp:nat.h p (self P pO h p)
+nat_induction = 𝐘self:∀P:nat→Prop.P O→(∀n:nat.P n→P (S n))→∀n:nat.P n.λP:nat→Prop.λpO:P O.λh:∀n:nat.P n→P (S n).λn:nat.n (P n) pO (λp:nat.h p (self P pO h p))
     :∀P:nat→Prop.P O→(∀n:nat.P n→P (S n))→∀n:nat.P n
 ```
 

--- a/rooster_kernel/src/lib.rs
+++ b/rooster_kernel/src/lib.rs
@@ -1673,6 +1673,7 @@ impl std::fmt::Debug for Term {
                 f.write_str(" ")?;
                 let parenthesize_second = match **parameter_term {
                     Term::Application { .. } => true,
+                    Term::Lambda { .. } | Term::Forall { .. } => true,
                     _ => false,
                 };
                 if parenthesize_second {

--- a/rooster_kernel/tests/common/mod.rs
+++ b/rooster_kernel/tests/common/mod.rs
@@ -1,0 +1,108 @@
+use rooster_kernel::*;
+
+fn parse_identifier(input: &[char]) -> (String, &[char]) {
+    if input.len() < 1 {
+        return ("".to_string(), input);
+    }
+    if input[0] == '_' || input[0].is_alphanumeric() {
+        let mut output = String::from(input[0]);
+        let (rest_of_identifier, rest_of_input) = parse_identifier(&input[1..]);
+        output.push_str(&rest_of_identifier);
+        (output, rest_of_input)
+    } else {
+        ("".to_string(), input)
+    }
+}
+
+fn parse_application(input: &[char], previous_term: Term) -> (Term, &[char]) {
+    if input.len() >= 1 && input[0] == ' ' {
+        let (next_term, rest_of_input) = parse_term(&input[1..]);
+        let mut function_term = previous_term;
+        let mut parameter_term = next_term.clone();
+        if let Term::Application {
+            function_term: inner_function_term,
+            parameter_term: inner_parameter_term,
+            debug_context: _,
+        } = next_term
+        {
+            function_term = Term::Application {
+                function_term: Box::new(function_term),
+                parameter_term: Box::new(*inner_function_term),
+                debug_context: TermDebugContext::Ignore,
+            };
+            parameter_term = *inner_parameter_term;
+        }
+        (
+            Term::Application {
+                function_term: Box::new(function_term),
+                parameter_term: Box::new(parameter_term),
+                debug_context: TermDebugContext::Ignore,
+            },
+            rest_of_input,
+        )
+    } else {
+        (previous_term, input)
+    }
+}
+
+fn parse_term(input: &[char]) -> (Term, &[char]) {
+    match input[0] {
+        'λ' | '∀' | '𝐘' => {
+            let (binding_identifier, input2) = parse_identifier(&input[1..]);
+            assert!(input2[0] == ':');
+            let (binding_type, input3) = parse_term(&input2[1..]);
+            assert!(input3[0] == '.');
+            let (value_term, rest_of_input) = parse_term(&input3[1..]);
+            (
+                match input[0] {
+                    'λ' => Term::Lambda {
+                        binding_identifier: binding_identifier,
+                        binding_type: Box::new(binding_type),
+                        value_term: Box::new(value_term),
+                        debug_context: TermDebugContext::Ignore,
+                    },
+                    '∀' => Term::Forall {
+                        binding_identifier: binding_identifier,
+                        binding_type: Box::new(binding_type),
+                        value_term: Box::new(value_term),
+                        debug_context: TermDebugContext::Ignore,
+                    },
+                    '𝐘' => Term::FixedPoint {
+                        binding_identifier: binding_identifier,
+                        binding_type: Box::new(binding_type),
+                        value_term: Box::new(value_term),
+                        debug_context: TermDebugContext::Ignore,
+                    },
+                    _ => panic!(),
+                },
+                rest_of_input,
+            )
+        }
+        '(' => {
+            let (inner_term, input2) = parse_term(&input[1..]);
+            assert!(input2[0] == ')');
+            let mut rest_of_input = &input2[1..];
+            parse_application(rest_of_input, inner_term)
+        }
+        ch => {
+            assert!(ch == '_' || ch.is_alphanumeric());
+            let (identifier_name, rest_of_input) = parse_identifier(input);
+            let identifier_term = Term::Identifier(identifier_name, TermDebugContext::Ignore);
+            parse_application(rest_of_input, identifier_term)
+        }
+    }
+}
+
+pub fn execute(code: &[(&str, &str, &str)]) {
+    let mut state = State::new();
+    for statement in code {
+        match state.try_define(
+            &statement.0.to_string(),
+            parse_term(&statement.1.chars().collect::<Vec<_>>()).0,
+            parse_term(&statement.2.chars().collect::<Vec<_>>()).0,
+        ) {
+            Ok(_) => (),
+            Err(_) => panic!(),
+        }
+    }
+}

--- a/rooster_kernel/tests/logic_tests.rs
+++ b/rooster_kernel/tests/logic_tests.rs
@@ -40,8 +40,8 @@ fn conjunction_implies_operand() {
 fn disjunction_is_commutative() {
     common::execute(&[(
         "disjunction_is_commutative",
-        "∀A:Prop.∀B:Prop.∀_:∀P:Prop.∀_:∀_:A.P.∀_:∀_:B.P.P.∀S:Prop.∀_:∀_:B.S.∀_:∀_:A.S.S",
-        "λA:Prop.λB:Prop.λh:∀P:Prop.∀_:∀_:A.P.∀_:∀_:B.P.P.h ∀S:Prop.∀_:∀_:B.S.∀_:∀_:A.S.S λa:A.λQ:Prop.λ_:∀_:B.Q.λaq:∀_:A.Q.aq a λb:B.λQ:Prop.λbq:∀_:B.Q.λ_:∀_:A.Q.bq b",
+        "∀A:Prop.∀B:Prop.∀_:∀P:Prop.∀_:∀_:A.P.∀_:∀_:B.P.P.∀x:Prop.∀_:∀_:B.x.∀_:∀_:A.x.x",
+        "λA:Prop.λB:Prop.λh:∀P:Prop.∀_:∀_:A.P.∀_:∀_:B.P.P.h (∀x:Prop.∀_:∀_:B.x.∀_:∀_:A.x.x) (λa:A.λQ:Prop.λ_:∀_:B.Q.λaq:∀_:A.Q.aq a) (λb:B.λQ:Prop.λbq:∀_:B.Q.λ_:∀_:A.Q.bq b)",
     )]);
 }
 
@@ -59,7 +59,7 @@ fn disjunction_of_implication_is_commutative() {
     common::execute(&[(
         "disjunction_is_commutative",
         "∀A:Prop.∀B:Prop.∀_:∀P:Prop.∀_:∀_:A.P.∀_:∀_:B.P.P.∀S:Prop.∀_:∀_:B.S.∀_:∀_:A.S.S",
-        "λA:Prop.λB:Prop.λh:∀P:Prop.∀_:∀_:A.P.∀_:∀_:B.P.P.h ∀S:Prop.∀_:∀_:B.S.∀_:∀_:A.S.S λa:A.λQ:Prop.λ_:∀_:B.Q.λaq:∀_:A.Q.aq a λb:B.λQ:Prop.λbq:∀_:B.Q.λ_:∀_:A.Q.bq b",
+        "λA:Prop.λB:Prop.λh:∀P:Prop.∀_:∀_:A.P.∀_:∀_:B.P.P.h (∀x:Prop.∀_:∀_:B.x.∀_:∀_:A.x.x) (λa:A.λQ:Prop.λ_:∀_:B.Q.λaq:∀_:A.Q.aq a) (λb:B.λQ:Prop.λbq:∀_:B.Q.λ_:∀_:A.Q.bq b)",
     ), (
         "disjunction_of_implication_is_commutative",
         "∀A:Prop.∀B:Prop.∀_:(∀P:Prop.∀_:(∀_:(∀_:A.B).P).∀_:(∀_:(∀_:B.A).P).P).∀Q:Prop.∀_:(∀_:(∀_:B.A).Q).∀_:(∀_:(∀_:A.B).Q).Q",
@@ -69,13 +69,16 @@ fn disjunction_of_implication_is_commutative() {
 
 #[test]
 fn equivalence_implies_implication() {
-    common::execute(&[(
-        "conjunction_implies_operand",
-        "∀A:Prop.∀B:Prop.∀_:∀P:Prop.∀_:∀_:A.∀_:B.P.P.A",
-        "λA:Prop.λB:Prop.λh:∀P:Prop.∀_:∀_:A.∀_:B.P.P.h A λx:A.λy:B.x",
-    ), (
-        "equivalence_implies_implication",
-        "∀A:Prop.∀B:Prop.∀_:(∀P:Prop.∀_:(∀_:(∀_:A.B).∀_:(∀_:B.A).P).P).∀_:A.B",
-        "λA:Prop.λB:Prop.conjunction_implies_operand (∀_:A.B) (∀_:B.A)",
-    )]);
+    common::execute(&[
+        (
+            "conjunction_implies_operand",
+            "∀A:Prop.∀B:Prop.∀_:∀P:Prop.∀_:∀_:A.∀_:B.P.P.A",
+            "λA:Prop.λB:Prop.λh:∀P:Prop.∀_:∀_:A.∀_:B.P.P.h A λx:A.λy:B.x",
+        ),
+        (
+            "equivalence_implies_implication",
+            "∀A:Prop.∀B:Prop.∀_:(∀P:Prop.∀_:(∀_:(∀_:A.B).∀_:(∀_:B.A).P).P).∀_:A.B",
+            "λA:Prop.λB:Prop.conjunction_implies_operand (∀_:A.B) (∀_:B.A)",
+        ),
+    ]);
 }

--- a/rooster_kernel/tests/logic_tests.rs
+++ b/rooster_kernel/tests/logic_tests.rs
@@ -1,0 +1,10 @@
+mod common;
+
+#[test]
+fn implication_is_reflexive() {
+    common::execute(&[(
+        "implication_is_reflexive",
+        "∀T:Prop.∀_:T.T",
+        "λT:Prop.λx:T.x",
+    )]);
+}

--- a/rooster_kernel/tests/logic_tests.rs
+++ b/rooster_kernel/tests/logic_tests.rs
@@ -8,3 +8,74 @@ fn implication_is_reflexive() {
         "λT:Prop.λx:T.x",
     )]);
 }
+
+#[test]
+fn implication_works() {
+    common::execute(&[(
+        "implication_works",
+        "∀T:Prop.∀P:Prop.∀_:T.∀_:∀_:T.P.P",
+        "λT:Prop.λP:Prop.λx:T.λy:∀_:T.P.y x",
+    )]);
+}
+
+#[test]
+fn consequent_always_exists() {
+    common::execute(&[(
+        "consequent_always_exists",
+        "∀T:Prop.∀Q:Prop.∀_:(∀P:Prop.∀_:(∀_:T.P).Q).Q",
+        "λT:Prop.λQ:Prop.λh:∀P:Prop.∀_:(∀_:T.P).Q.h T λx:T.x",
+    )]);
+}
+
+#[test]
+fn conjunction_implies_operand() {
+    common::execute(&[(
+        "conjunction_implies_operand",
+        "∀A:Prop.∀B:Prop.∀_:∀P:Prop.∀_:∀_:A.∀_:B.P.P.A",
+        "λA:Prop.λB:Prop.λh:∀P:Prop.∀_:∀_:A.∀_:B.P.P.h A λx:A.λy:B.x",
+    )]);
+}
+
+#[test]
+fn disjunction_is_commutative() {
+    common::execute(&[(
+        "disjunction_is_commutative",
+        "∀A:Prop.∀B:Prop.∀_:∀P:Prop.∀_:∀_:A.P.∀_:∀_:B.P.P.∀S:Prop.∀_:∀_:B.S.∀_:∀_:A.S.S",
+        "λA:Prop.λB:Prop.λh:∀P:Prop.∀_:∀_:A.P.∀_:∀_:B.P.P.h ∀S:Prop.∀_:∀_:B.S.∀_:∀_:A.S.S λa:A.λQ:Prop.λ_:∀_:B.Q.λaq:∀_:A.Q.aq a λb:B.λQ:Prop.λbq:∀_:B.Q.λ_:∀_:A.Q.bq b",
+    )]);
+}
+
+#[test]
+fn proposition_and_its_negation_is_false() {
+    common::execute(&[(
+        "proposition_and_its_negation_is_false",
+        "∀A:Prop.∀_:(∀Q:Prop.∀_:(∀_:A.∀_:(∀_:A.∀x:Prop.x).Q).Q).∀x:Prop.x",
+        "λA:Prop.λh:∀Q:Prop.∀_:(∀_:A.∀_:(∀_:A.∀x:Prop.x).Q).Q.h (∀x:Prop.x) λa:A.λnot_a:∀_:A.∀x:Prop.x.not_a a",
+    )]);
+}
+
+#[test]
+fn disjunction_of_implication_is_commutative() {
+    common::execute(&[(
+        "disjunction_is_commutative",
+        "∀A:Prop.∀B:Prop.∀_:∀P:Prop.∀_:∀_:A.P.∀_:∀_:B.P.P.∀S:Prop.∀_:∀_:B.S.∀_:∀_:A.S.S",
+        "λA:Prop.λB:Prop.λh:∀P:Prop.∀_:∀_:A.P.∀_:∀_:B.P.P.h ∀S:Prop.∀_:∀_:B.S.∀_:∀_:A.S.S λa:A.λQ:Prop.λ_:∀_:B.Q.λaq:∀_:A.Q.aq a λb:B.λQ:Prop.λbq:∀_:B.Q.λ_:∀_:A.Q.bq b",
+    ), (
+        "disjunction_of_implication_is_commutative",
+        "∀A:Prop.∀B:Prop.∀_:(∀P:Prop.∀_:(∀_:(∀_:A.B).P).∀_:(∀_:(∀_:B.A).P).P).∀Q:Prop.∀_:(∀_:(∀_:B.A).Q).∀_:(∀_:(∀_:A.B).Q).Q",
+        "λA:Prop.λB:Prop.disjunction_is_commutative (∀_:A.B) (∀_:B.A)",
+    )]);
+}
+
+#[test]
+fn equivalence_implies_implication() {
+    common::execute(&[(
+        "conjunction_implies_operand",
+        "∀A:Prop.∀B:Prop.∀_:∀P:Prop.∀_:∀_:A.∀_:B.P.P.A",
+        "λA:Prop.λB:Prop.λh:∀P:Prop.∀_:∀_:A.∀_:B.P.P.h A λx:A.λy:B.x",
+    ), (
+        "equivalence_implies_implication",
+        "∀A:Prop.∀B:Prop.∀_:(∀P:Prop.∀_:(∀_:(∀_:A.B).∀_:(∀_:B.A).P).P).∀_:A.B",
+        "λA:Prop.λB:Prop.conjunction_implies_operand (∀_:A.B) (∀_:B.A)",
+    )]);
+}

--- a/test.roo
+++ b/test.roo
@@ -90,7 +90,7 @@ let add: nat -> nat -> nat = recursive(self: nat -> nat -> nat) |n, m: nat| n(
     nat, m, |p: nat| S(self(p, m))
 );
 
-let nat_inductive_hypothesis: @(P: nat -> Prop)
+let nat_induction: @(P: nat -> Prop)
     P(O) -> {@(n: nat) P(n) -> P(S(n))} -> @(n: nat) P(n)
 = recursive(self: @(P: nat -> Prop)
     P(O) -> {@(n: nat) P(n) -> P(S(n))} -> @(n: nat) P(n)
@@ -102,4 +102,5 @@ let nat_inductive_hypothesis: @(P: nat -> Prop)
     n(P(n), pO, |p: nat| h(p, self(P, pO, h, p)))
 ;
 
+let equals: @(a, b: nat) Prop = |a, b: nat| @(P: nat -> Prop) P(a) <-> P(b);
 

--- a/test.roo
+++ b/test.roo
@@ -102,5 +102,3 @@ let nat_induction: @(P: nat -> Prop)
     n(P(n), pO, |p: nat| h(p, self(P, pO, h, p)))
 ;
 
-let equals: @(a, b: nat) Prop = |a, b: nat| @(P: nat -> Prop) P(a) <-> P(b);
-


### PR DESCRIPTION
Uses `cargo test` to implement correctness checks on kernel code. These checks only detect whether definitions known to check as correct stop doing so. They don't enforce kernel consistency by attempting to prove `⊥`, which could be done as a separate fuzzing test.