### PR TITLE
Fix kernel freeze detected via fuzzing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1419%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
+[![Kernel size](https://img.shields.io/badge/kernel-1421%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
 
 An automated proof checker based on the Calculus of Constructions
 plus inductive types.

--- a/rooster_kernel/src/lib.rs
+++ b/rooster_kernel/src/lib.rs
@@ -1520,6 +1520,7 @@ impl Term {
                         // at strictly positive positions,
                         // and the entire term is of type Set.
                         value_term.check_strict_positivity(binding_identifier)?;
+                        value_term.infer_type_recursive(state, stack)?;
                         stack.pop();
                         return Ok(Self::Identifier(
                             "Set".to_string(),
@@ -1662,6 +1663,7 @@ impl Term {
                             } = &**current_term
                             {
                                 current_binding_type.check_strict_positivity(binding_identifier)?;
+                                current_binding_type.infer_type_recursive(state, stack)?;
                                 current_term = current_value_term;
                             } else {
                                 break;


### PR DESCRIPTION
Kernel type-checking would not reach some subterms, which could contain infinitely recursing functions that would get expanded.