### PR TITLE
Inductive redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Syntax extensions:
 | CoC terms | `A(B)` `\|x: A\| B` `@(x: A) B` `Prop` `Type(n)` `{A}` |
 | CoC sentences | `let a: A = B;` |
 | Intuitionistic logic | `A -> B` `False` `^A` `A /\ B` `A \/ B` `exists(x: A) B` `A <-> B` |
-| Inductive types | `?` `recursive(x: A) B` `Set` `constructor(A) B` |
+| Inductive types | `recursive(x: A) B` `Set` `constructor(A) B` |
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1857%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
+[![Kernel size](https://img.shields.io/badge/kernel-1820%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
 
 An automated proof checker based on the Calculus of Constructions
 plus inductive types.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1889%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
+[![Kernel size](https://img.shields.io/badge/kernel-1911%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
 
 An automated proof checker based on the Calculus of Constructions
 plus inductive types.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1891%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
+[![Kernel size](https://img.shields.io/badge/kernel-1889%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
 
 An automated proof checker based on the Calculus of Constructions
 plus inductive types.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1557%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
+[![Kernel size](https://img.shields.io/badge/kernel-1857%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
 
 An automated proof checker based on the Calculus of Constructions
 plus inductive types.
@@ -44,15 +44,15 @@ disjunction_of_implication_is_commutative = λA:Prop.λB:Prop.disjunction_is_com
     :∀A:Prop.∀B:Prop.(∀$465:Prop.((A→B)→$465)→((B→A)→$465)→$465)→∀$474:Prop.((B→A)→$474)→((A→B)→$474)→$474
 equivalence_implies_implication = λA:Prop.λB:Prop.conjunction_implies_operand (A→B) (B→A)
     :∀A:Prop.∀B:Prop.(∀$494:Prop.((A→B)→(B→A)→$494)→$494)→A→B
-nat = 𝐘self:Set.∀T:? Set.T→(self→T)→T
+nat = 𝐘self:Set.∀R:Type.∀T:R.T→(self→T)→T
     :Set
-O = λT:? nat.λa:T.λb:nat→T.a
+O = ℺nat.λR:Type.λT:R.λa:T.λb:nat→T.a
     :nat
-S = λx:nat.λT:? nat.λa:T.λb:nat→T.b x
+S = λx:nat.℺nat.λR:Type.λT:R.λa:T.λb:nat→T.b x
     :nat→nat
-add = 𝐘self:nat→nat→nat.λn:nat.λm:nat.n nat m (λp:nat.S (self p m))
+add = 𝐘self:nat→nat→nat.λn:nat.λm:nat.n Set nat m (λp:nat.S (self p m))
     :nat→nat→nat
-nat_induction = 𝐘self:∀P:nat→Prop.P O→(∀n:nat.P n→P (S n))→∀n:nat.P n.λP:nat→Prop.λpO:P O.λh:∀n:nat.P n→P (S n).λn:nat.n (P n) pO (λp:nat.h p (self P pO h p))
+nat_induction = 𝐘self:∀P:nat→Prop.P O→(∀n:nat.P n→P (S n))→∀n:nat.P n.λP:nat→Prop.λpO:P O.λh:∀n:nat.P n→P (S n).λn:nat.n Prop (P n) pO (λp:nat.h p (self P pO h p))
     :∀P:nat→Prop.P O→(∀n:nat.P n→P (S n))→∀n:nat.P n
 ```
 
@@ -69,7 +69,7 @@ Syntax extensions:
 | CoC terms | `A(B)` `\|x: A\| B` `@(x: A) B` `Prop` `Type(n)` `{A}` |
 | CoC sentences | `let a: A = B;` |
 | Intuitionistic logic | `A -> B` `False` `^A` `A /\ B` `A \/ B` `exists(x: A) B` `A <-> B` |
-| Inductive types | `?` `recursive(x: A) B` `Set` |
+| Inductive types | `?` `recursive(x: A) B` `Set` `constructor(A) B` |
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1877%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
+[![Kernel size](https://img.shields.io/badge/kernel-1892%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
 
 An automated proof checker based on the Calculus of Constructions
 plus inductive types.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1911%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
+[![Kernel size](https://img.shields.io/badge/kernel-1952%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
 
 An automated proof checker based on the Calculus of Constructions
 plus inductive types.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1820%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
+[![Kernel size](https://img.shields.io/badge/kernel-1862%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
 
 An automated proof checker based on the Calculus of Constructions
 plus inductive types.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1892%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
+[![Kernel size](https://img.shields.io/badge/kernel-1891%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
 
 An automated proof checker based on the Calculus of Constructions
 plus inductive types.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1862%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
+[![Kernel size](https://img.shields.io/badge/kernel-1867%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
 
 An automated proof checker based on the Calculus of Constructions
 plus inductive types.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1952%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
+[![Kernel size](https://img.shields.io/badge/kernel-1955%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
 
 An automated proof checker based on the Calculus of Constructions
 plus inductive types.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rooster
-[![Kernel size](https://img.shields.io/badge/kernel-1867%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
+[![Kernel size](https://img.shields.io/badge/kernel-1877%20SLOC-blue)](rooster_kernel/src/lib.rs) [![Rust CI workflow](https://github.com/aerkiaga/rooster/actions/workflows/rust.yml/badge.svg)](.github/workflows/rust.yml)
 
 An automated proof checker based on the Calculus of Constructions
 plus inductive types.

--- a/rooster/src/ast.rs
+++ b/rooster/src/ast.rs
@@ -28,6 +28,11 @@ pub enum Expression {
         value_expression: Box<Expression>,
         span: (usize, usize),
     },
+    Constructor {
+        type_expression: Box<Expression>,
+        value_expression: Box<Expression>,
+        span: (usize, usize),
+    },
 }
 
 impl Expression {
@@ -51,6 +56,11 @@ impl Expression {
             } => *span,
             Self::FixedPoint {
                 binding: _,
+                value_expression: _,
+                span,
+            } => *span,
+            Self::Constructor {
+                type_expression: _,
                 value_expression: _,
                 span,
             } => *span,

--- a/rooster/src/diagnostics.rs
+++ b/rooster/src/diagnostics.rs
@@ -249,5 +249,8 @@ pub fn emit_kernel_diagnostic(error: &KernelError, code: &String, source_id: &St
         KernelError::NonprimitiveRecursiveFunction { full_term_context } => {
             println!("NonprimitiveRecursiveFunction");
         }
+        KernelError::SelfReferencingRecursiveType { full_term_context } => {
+            println!("SelfReferencingRecursiveType");
+        }
     }
 }

--- a/rooster/src/diagnostics.rs
+++ b/rooster/src/diagnostics.rs
@@ -198,11 +198,10 @@ pub fn emit_kernel_diagnostic(error: &KernelError, code: &String, source_id: &St
         } => {
             Report::build(ReportKind::Error, source_id, 0)
                 .with_message(format!(
-                    "term's type must be {}, {}, {} or {}",
+                    "term's type must be {}, {} or {}",
                     "Set".fg(Color::Green),
                     "Prop".fg(Color::Green),
                     "Type".fg(Color::Green),
-                    "? M".fg(Color::Green),
                 ))
                 .with_note(format!(
                     "the given term has type {}",

--- a/rooster/src/kernel.rs
+++ b/rooster/src/kernel.rs
@@ -45,6 +45,15 @@ pub fn new_term(expression: &Expression) -> Term {
             value_term: Box::new(new_term(value_expression)),
             debug_context: TermDebugContext::CodeSpan(*span),
         },
+        Expression::Constructor {
+            type_expression,
+            value_expression,
+            span,
+        } => Term::Constructor {
+            type_term: Box::new(new_term(type_expression)),
+            value_term: Box::new(new_term(value_expression)),
+            debug_context: TermDebugContext::CodeSpan(*span),
+        },
     }
 }
 

--- a/rooster/src/parser.rs
+++ b/rooster/src/parser.rs
@@ -12,9 +12,7 @@ fn parser() -> impl Parser<char, Vec<Statement>, Error = Simple<char>> {
         .then_ignore(comment.separated_by(text::whitespace()).ignored())
         .then_ignore(text::whitespace())
         .boxed();
-    let identifier = just('?')
-        .map_with_span(|_, sp: std::ops::Range<usize>| ("?".to_string(), (sp.start(), sp.end())))
-        .or(filter(|c| char::is_alphabetic(*c))
+    let identifier = filter(|c| char::is_alphabetic(*c))
             .or(just('_'))
             .then(
                 filter(|c| char::is_alphabetic(*c))
@@ -26,7 +24,7 @@ fn parser() -> impl Parser<char, Vec<Statement>, Error = Simple<char>> {
                 let mut s = String::from(t.0);
                 s.push_str(&t.1);
                 (s, (sp.start(), sp.end()))
-            }));
+            });
     let expression = recursive(
         |nested_expression: Recursive<char, Expression, Simple<char>>| {
             let identifier_list = identifier

--- a/rooster/src/parser.rs
+++ b/rooster/src/parser.rs
@@ -13,18 +13,18 @@ fn parser() -> impl Parser<char, Vec<Statement>, Error = Simple<char>> {
         .then_ignore(text::whitespace())
         .boxed();
     let identifier = filter(|c| char::is_alphabetic(*c))
-            .or(just('_'))
-            .then(
-                filter(|c| char::is_alphabetic(*c))
-                    .or(just('_'))
-                    .repeated()
-                    .collect::<String>(),
-            )
-            .map_with_span(|t, sp: std::ops::Range<usize>| {
-                let mut s = String::from(t.0);
-                s.push_str(&t.1);
-                (s, (sp.start(), sp.end()))
-            });
+        .or(just('_'))
+        .then(
+            filter(|c| char::is_alphabetic(*c))
+                .or(just('_'))
+                .repeated()
+                .collect::<String>(),
+        )
+        .map_with_span(|t, sp: std::ops::Range<usize>| {
+            let mut s = String::from(t.0);
+            s.push_str(&t.1);
+            (s, (sp.start(), sp.end()))
+        });
     let expression = recursive(
         |nested_expression: Recursive<char, Expression, Simple<char>>| {
             let identifier_list = identifier

--- a/rooster/src/parser.rs
+++ b/rooster/src/parser.rs
@@ -113,6 +113,17 @@ fn parser() -> impl Parser<char, Vec<Statement>, Error = Simple<char>> {
                         span: new_span,
                     }
                 });
+            let constructor_expression = just("constructor(")
+                .ignored()
+                .padded_by(token_separator.clone())
+                .then(nested_expression.clone())
+                .then_ignore(just(')').padded_by(token_separator.clone()))
+                .then(nested_expression.clone())
+                .map_with_span(|t, sp| Expression::Constructor {
+                    type_expression: Box::new(t.0 .1),
+                    value_expression: Box::new(t.1),
+                    span: (sp.start(), sp.end()),
+                });
             // alias: ∃x:A.B := ∀y:Prop.∀z:(∀x:A.(∀w:B.y)).y
             let exists_expression = just("exists(")
                 .ignored()
@@ -131,6 +142,7 @@ fn parser() -> impl Parser<char, Vec<Statement>, Error = Simple<char>> {
                 lambda_expression,
                 forall_expression,
                 fixed_point_expression,
+                constructor_expression,
                 exists_expression,
                 identifier_expression,
             ));

--- a/rooster_kernel/fuzz/fuzz_targets/default.rs
+++ b/rooster_kernel/fuzz/fuzz_targets/default.rs
@@ -92,14 +92,16 @@ fn generate_term(data: &[u8]) -> (Option<Term>, &[u8]) {
 fn generate_definition<'a, 'b>(data: &'a [u8], state: &'b State) -> Result<((Term, Term), &'a [u8]), KernelError> {
     let (value_term_option, remaining_data) = generate_term(data);
     let value_term = value_term_option.unwrap();
+    println!("value_term: {:?}", value_term); //D
     let type_term = value_term.infer_type(state)?;
     return Ok(((type_term, value_term), remaining_data));
 }
 
 fuzz_target!(|data: &[u8]| {
     let mut state = State::new();
+    let stat = vec![138, 88, 202, 229, 33, 191, 221, 4, 5, 40, 108, 40];
     let mut definitions = vec![];
-    let mut remaining_data = &*data;
+    let mut remaining_data = &*stat;
     let mut index = 0;
     let mut r#false = Term::Forall {
         binding_identifier: "P".to_string(),
@@ -120,6 +122,7 @@ fuzz_target!(|data: &[u8]| {
         let identifier = format!("x{}", index);
         let (definition_type, definition_value) = (definition.0.clone(), definition.1.clone());
         let mut normalized_type = definition.0.clone();
+        println!("{} = {:?}\n\t:{:?}", identifier, definition_value, definition_type); //D
         match state.try_define(&identifier, definition.0, definition.1) {
             Ok(_) => (),
             Err(_) => return,

--- a/rooster_kernel/fuzz/fuzz_targets/default.rs
+++ b/rooster_kernel/fuzz/fuzz_targets/default.rs
@@ -116,9 +116,9 @@ fn generate_definition<'a, 'b>(data: &'a [u8], state: &'b State) -> Result<((Ter
 
 fuzz_target!(|data: &[u8]| {
     let mut state = State::new();
-    //let stat = vec![123, 69, 123, 223, 196, 223, 40, 37, 0, 223, 217];
+    //let stat = vec![127, 176, 176, 184, 0, 64, 0, 65];
     let mut definitions = vec![];
-    let mut remaining_data = &*data;
+    let mut remaining_data = &*data; //&*stat;
     let mut index = 0;
     let mut r#false = Term::Forall {
         binding_identifier: "P".to_string(),

--- a/rooster_kernel/fuzz/fuzz_targets/default.rs
+++ b/rooster_kernel/fuzz/fuzz_targets/default.rs
@@ -11,7 +11,7 @@ fn generate_term(data: &[u8]) -> (Option<Term>, &[u8]) {
         0..=63 =>
             (Some(Term::Identifier(format!("x{}", data[0] % 4), TermDebugContext::Ignore)), &data[1..]),
         64..=127 =>
-            (Some(Term::Identifier(["?", "Prop", "Set", "Type(1)"][(data[0] % 4) as usize].to_string(), TermDebugContext::Ignore)), &data[1..]),
+            (Some(Term::Identifier(["Prop", "Set", "Type(1)"][(data[0] % 3) as usize].to_string(), TermDebugContext::Ignore)), &data[1..]),
         128..=159 => {
             let (function_term_option, data2) = generate_term(&data[1..]);
             let (parameter_term_option, data3) = generate_term(data2);
@@ -67,7 +67,7 @@ fn generate_term(data: &[u8]) -> (Option<Term>, &[u8]) {
                 debug_context: TermDebugContext::Ignore,
             }), data3)
         },
-        224..=255 => {
+        224..=239 => {
             let identifier = format!("x{}", data[0] % 4);
             let (type_term_option, data2) = generate_term(&data[1..]);
             let (value_term_option, data3) = generate_term(data2);
@@ -86,22 +86,39 @@ fn generate_term(data: &[u8]) -> (Option<Term>, &[u8]) {
                 debug_context: TermDebugContext::Ignore,
             }), data3)
         },
+        240..=255 => {
+            let (type_term_option, data2) = generate_term(&data[1..]);
+            let (value_term_option, data3) = generate_term(data2);
+            let type_term = match type_term_option {
+                Some(x) => x,
+                None => return (generate_term(&vec![data[0] - 128]).0, &data[data.len()..]),
+            };
+            let value_term = match value_term_option {
+                Some(x) => x,
+                None => return (generate_term(&vec![data[0] - 128]).0, &data[data.len()..]),
+            };
+            (Some(Term::Constructor{
+                type_term: Box::new(type_term),
+                value_term: Box::new(value_term),
+                debug_context: TermDebugContext::Ignore,
+            }), data3)
+        },
     }
 }
 
 fn generate_definition<'a, 'b>(data: &'a [u8], state: &'b State) -> Result<((Term, Term), &'a [u8]), KernelError> {
     let (value_term_option, remaining_data) = generate_term(data);
     let value_term = value_term_option.unwrap();
-    println!("value_term: {:?}", value_term); //D
+    //println!("value_term: {:?}", value_term); //D
     let type_term = value_term.infer_type(state)?;
     return Ok(((type_term, value_term), remaining_data));
 }
 
 fuzz_target!(|data: &[u8]| {
     let mut state = State::new();
-    let stat = vec![138, 88, 202, 229, 33, 191, 221, 4, 5, 40, 108, 40];
+    //let stat = vec![123, 69, 123, 223, 196, 223, 40, 37, 0, 223, 217];
     let mut definitions = vec![];
-    let mut remaining_data = &*stat;
+    let mut remaining_data = &*data;
     let mut index = 0;
     let mut r#false = Term::Forall {
         binding_identifier: "P".to_string(),
@@ -122,7 +139,7 @@ fuzz_target!(|data: &[u8]| {
         let identifier = format!("x{}", index);
         let (definition_type, definition_value) = (definition.0.clone(), definition.1.clone());
         let mut normalized_type = definition.0.clone();
-        println!("{} = {:?}\n\t:{:?}", identifier, definition_value, definition_type); //D
+        //println!("{} = {:?}\n\t:{:?}", identifier, definition_value, definition_type); //D
         match state.try_define(&identifier, definition.0, definition.1) {
             Ok(_) => (),
             Err(_) => return,

--- a/rooster_kernel/fuzz/fuzz_targets/default.rs
+++ b/rooster_kernel/fuzz/fuzz_targets/default.rs
@@ -116,9 +116,9 @@ fn generate_definition<'a, 'b>(data: &'a [u8], state: &'b State) -> Result<((Ter
 
 fuzz_target!(|data: &[u8]| {
     let mut state = State::new();
-    //let stat = vec![127, 176, 176, 184, 0, 64, 0, 65];
+    //let stat = vec![];
     let mut definitions = vec![];
-    let mut remaining_data = &*data; //&*stat;
+    let mut remaining_data = &*data;
     let mut index = 0;
     let mut r#false = Term::Forall {
         binding_identifier: "P".to_string(),

--- a/rooster_kernel/fuzz/fuzz_targets/default.rs
+++ b/rooster_kernel/fuzz/fuzz_targets/default.rs
@@ -11,7 +11,7 @@ fn generate_term(data: &[u8]) -> (Option<Term>, &[u8]) {
         0..=63 =>
             (Some(Term::Identifier(format!("x{}", data[0] % 4), TermDebugContext::Ignore)), &data[1..]),
         64..=127 =>
-            (Some(Term::Identifier(["Prop", "Set", "Type(1)"][(data[0] % 3) as usize].to_string(), TermDebugContext::Ignore)), &data[1..]),
+            (Some(Term::Identifier(["Prop", "Set", "Type"][(data[0] % 3) as usize].to_string(), TermDebugContext::Ignore)), &data[1..]),
         128..=159 => {
             let (function_term_option, data2) = generate_term(&data[1..]);
             let (parameter_term_option, data3) = generate_term(data2);

--- a/rooster_kernel/src/lib.rs
+++ b/rooster_kernel/src/lib.rs
@@ -1023,6 +1023,12 @@ impl Term {
         self.alpha_normalize();
     }
 
+    pub fn partial_normalize_inner(self: &mut Self, state: &State, stack: &Vec<(String, Self)>) {
+        self.delta_normalize_inner(state, stack);
+        self.normalize();
+        self.alpha_normalize();
+    }
+
     fn get_debug_context<'a>(self: &'a Self) -> &'a TermDebugContext {
         match self {
             Self::Identifier(_, db) => db,
@@ -1997,8 +2003,7 @@ impl Term {
                 debug_context: _,
             } => {
                 let mut value_term_type = value_term.infer_type_recursive(state, stack)?;
-                value_term_type.infer_type_recursive(state, stack)?;
-                value_term_type.full_normalize_inner(state, stack);
+                value_term_type.partial_normalize_inner(state, stack);
                 let mut expanded_type_term = *type_term.clone();
                 expanded_type_term.infer_type_recursive(state, stack)?;
                 expanded_type_term.full_normalize_inner(state, stack);

--- a/rooster_kernel/src/lib.rs
+++ b/rooster_kernel/src/lib.rs
@@ -1498,18 +1498,18 @@ impl Term {
                     }
                     break;
                 }
-                let old_identifier = template_constructor_params[n].0.clone();
-                for m in 0..n {
+                let old_identifier = template_constructor_params[c].0.clone();
+                for m in 0..c {
                     template_constructor_params[m].1.replace(
                         &old_identifier,
                         &Self::Identifier(new_identifier.clone(), TermDebugContext::Ignore),
                     );
                 }
                 template_constructor_result.replace(
-                    template_constructor_params[n].0,
+                    template_constructor_params[c].0,
                     &Self::Identifier(new_identifier.clone(), TermDebugContext::Ignore),
                 );
-                *template_constructor_params[n].0 = new_identifier;
+                *template_constructor_params[c].0 = new_identifier;
             }
             // build up inductive instance
             let application = Self::build_application((

--- a/rooster_kernel/src/lib.rs
+++ b/rooster_kernel/src/lib.rs
@@ -1559,7 +1559,7 @@ impl Term {
             *constructors[n].1 = modified_constructor;
         }
         // handle the result
-        *self_result = parameter_term.clone();
+        self_result.replace(&arbitrary_identifier, parameter_term);
 
         if let Self::Forall {
             binding_identifier: _,

--- a/rooster_kernel/src/lib.rs
+++ b/rooster_kernel/src/lib.rs
@@ -1653,8 +1653,7 @@ impl Term {
                             parameter_term.infer_type_recursive(state, stack)?;
                         parameter_type.full_normalize_inner(state, stack);
                         let mut expected_parameter_type = binding_type.clone();
-                        expected_parameter_type.infer_type_recursive(state, stack)?;
-                        expected_parameter_type.full_normalize_inner(state, stack);
+                        expected_parameter_type.partial_normalize_inner(state, stack);
                         let mut actual_function_term = function_term.clone();
                         let mut generic_identifier = "".to_string();
                         let is_match_term = if let Self::Application {
@@ -1914,8 +1913,7 @@ impl Term {
             } => {
                 binding_type.infer_type_recursive(state, stack)?;
                 let mut normalized_binding_type = binding_type.clone();
-                normalized_binding_type.infer_type_recursive(state, stack)?;
-                normalized_binding_type.full_normalize_inner(state, stack);
+                normalized_binding_type.partial_normalize_inner(state, stack);
                 stack.push((binding_identifier.clone(), *normalized_binding_type.clone()));
                 let inner_type = value_term.infer_type_recursive(state, stack)?;
                 if inner_type.contains(binding_identifier) {
@@ -2031,9 +2029,9 @@ impl Term {
                 value_term_type.partial_normalize_inner(state, stack);
                 let mut expanded_type_term = *type_term.clone();
                 expanded_type_term.infer_type_recursive(state, stack)?;
-                expanded_type_term.full_normalize_inner(state, stack);
+                expanded_type_term.partial_normalize_inner(state, stack);
                 expanded_type_term.fixed_point_reduce(true);
-                expanded_type_term.full_normalize_inner(state, stack);
+                expanded_type_term.partial_normalize_inner(state, stack);
                 if value_term_type == expanded_type_term {
                     return Ok(*type_term.clone());
                 } else {

--- a/rooster_kernel/src/lib.rs
+++ b/rooster_kernel/src/lib.rs
@@ -2033,7 +2033,6 @@ impl Term {
                 expanded_type_term.infer_type_recursive(state, stack)?;
                 expanded_type_term.full_normalize_inner(state, stack);
                 expanded_type_term.fixed_point_reduce(true);
-                expanded_type_term.infer_type_recursive(state, stack)?;
                 expanded_type_term.full_normalize_inner(state, stack);
                 if value_term_type == expanded_type_term {
                     return Ok(*type_term.clone());

--- a/rooster_kernel/src/lib.rs
+++ b/rooster_kernel/src/lib.rs
@@ -1799,8 +1799,23 @@ impl Term {
                 stack.push((binding_identifier.clone(), *binding_type.clone()));
                 let inner_type = value_term.infer_type_recursive(state, stack)?;
                 stack.pop();
+                let mut final_binding_identifier = binding_identifier.clone();
+                // rename binding identifier to avoid name collisions
+                if binding_type.contains(binding_identifier) {
+                    let mut suffix: u64 = 0;
+                    let mut new_identifier;
+                    'rep: loop {
+                        new_identifier = format!("{}{}", binding_identifier, suffix);
+                        if binding_type.contains(&new_identifier) {
+                            suffix += 1;
+                            continue 'rep;
+                        }
+                        break;
+                    }
+                    final_binding_identifier = new_identifier;
+                }
                 let output_type = Self::Forall {
-                    binding_identifier: binding_identifier.clone(),
+                    binding_identifier: final_binding_identifier,
                     binding_type: binding_type.clone(),
                     value_term: Box::new(inner_type),
                     debug_context: TermDebugContext::TypeOf(Box::new(debug_context.clone())),

--- a/rooster_kernel/src/lib.rs
+++ b/rooster_kernel/src/lib.rs
@@ -832,6 +832,21 @@ impl Term {
             self.replace(name, &term.1);
         }
     }
+    
+    pub fn delta_normalize_inner(self: &mut Self, state: &State, stack: &Vec<(String, Self)>) {
+        for (name, term) in &state.terms {
+            let mut replace = true;
+            for (name2, _) in stack {
+                if name == name2 {
+                    replace = false;
+                    break;
+                }
+            }
+            if replace {
+                self.replace(name, &term.1);
+            }
+        }
+    }
 
     fn alpha_normalize_recursive(self: &mut Self, next_suffix: u64) {
         match self {
@@ -988,6 +1003,17 @@ impl Term {
     ///
     pub fn full_normalize(self: &mut Self, state: &State) {
         self.delta_normalize(state);
+        loop {
+            self.normalize();
+            if !self.fixed_point_reduce(false) {
+                break;
+            }
+        }
+        self.alpha_normalize();
+    }
+    
+    pub fn full_normalize_inner(self: &mut Self, state: &State, stack: &Vec<(String, Self)>) {
+        self.delta_normalize_inner(state, stack);
         loop {
             self.normalize();
             if !self.fixed_point_reduce(false) {
@@ -1614,9 +1640,9 @@ impl Term {
                     } => {
                         let mut parameter_type =
                             parameter_term.infer_type_recursive(state, stack)?;
-                        parameter_type.full_normalize(state);
+                        parameter_type.full_normalize_inner(state, stack);
                         let mut expected_parameter_type = binding_type.clone();
-                        expected_parameter_type.full_normalize(state);
+                        expected_parameter_type.full_normalize_inner(state, stack);
                         let mut actual_function_term = function_term.clone();
                         let mut generic_identifier = "".to_string();
                         let is_match_term = if let Self::Application {
@@ -1861,8 +1887,7 @@ impl Term {
             } => {
                 binding_type.infer_type_recursive(state, stack)?;
                 let mut normalized_binding_type = binding_type.clone();
-                // TODO: possible edge case if state variables are actually captured in the stack
-                normalized_binding_type.full_normalize(state);
+                normalized_binding_type.full_normalize_inner(state, stack);
                 stack.push((binding_identifier.clone(), *normalized_binding_type.clone()));
                 let inner_type = value_term.infer_type_recursive(state, stack)?;
                 match &**value_term {
@@ -1970,11 +1995,11 @@ impl Term {
                 debug_context: _,
             } => {
                 let mut value_term_type = value_term.infer_type_recursive(state, stack)?;
-                value_term_type.full_normalize(state);
+                value_term_type.full_normalize_inner(state, stack);
                 let mut expanded_type_term = *type_term.clone();
-                expanded_type_term.full_normalize(state);
+                expanded_type_term.full_normalize_inner(state, stack);
                 expanded_type_term.fixed_point_reduce(true);
-                expanded_type_term.full_normalize(state);
+                expanded_type_term.full_normalize_inner(state, stack);
                 if value_term_type == expanded_type_term {
                     return Ok(*type_term.clone());
                 } else {

--- a/rooster_kernel/src/lib.rs
+++ b/rooster_kernel/src/lib.rs
@@ -1730,19 +1730,23 @@ impl Term {
                 debug_context,
             } => {
                 let binding_type_type = binding_type.infer_type_recursive(state, stack)?;
-                let binding_type_type_type =
-                    binding_type_type.infer_type_recursive(state, stack)?;
-                let valid = if let Self::Identifier(s, _) = &binding_type_type_type {
-                    match &**s {
-                        "Type" => true,
-                        _ => {
-                            s.len() > 4
-                                && &s[..4] == "Type"
-                                && match s[4..].parse::<u64>() {
-                                    Ok(_) => true,
-                                    Err(_) => false,
-                                }
+                let valid = if let Self::Identifier(_, _) = &binding_type_type {
+                    let binding_type_type_type =
+                        binding_type_type.infer_type_recursive(state, stack)?;
+                    if let Self::Identifier(s, _) = &binding_type_type_type {
+                        match &**s {
+                            "Type" => true,
+                            _ => {
+                                s.len() > 4
+                                    && &s[..4] == "Type"
+                                    && match s[4..].parse::<u64>() {
+                                        Ok(_) => true,
+                                        Err(_) => false,
+                                    }
+                            }
                         }
+                    } else {
+                        false
                     }
                 } else {
                     false
@@ -1772,19 +1776,23 @@ impl Term {
                 debug_context,
             } => {
                 let binding_type_type = binding_type.infer_type_recursive(state, stack)?;
-                let binding_type_type_type =
-                    binding_type_type.infer_type_recursive(state, stack)?;
-                let valid = if let Self::Identifier(s, _) = &binding_type_type_type {
-                    match &**s {
-                        "Type" => true,
-                        _ => {
-                            s.len() > 4
-                                && &s[..4] == "Type"
-                                && match s[4..].parse::<u64>() {
-                                    Ok(_) => true,
-                                    Err(_) => false,
-                                }
+                let valid = if let Self::Identifier(_, _) = &binding_type_type {
+                    let binding_type_type_type =
+                        binding_type_type.infer_type_recursive(state, stack)?;
+                    if let Self::Identifier(s, _) = &binding_type_type_type {
+                        match &**s {
+                            "Type" => true,
+                            _ => {
+                                s.len() > 4
+                                    && &s[..4] == "Type"
+                                    && match s[4..].parse::<u64>() {
+                                        Ok(_) => true,
+                                        Err(_) => false,
+                                    }
+                            }
                         }
+                    } else {
+                        false
                     }
                 } else {
                     false
@@ -1807,23 +1815,27 @@ impl Term {
                         Box::new(debug_context.clone()),
                     ));
                 }
-                let inner_type_type = inner_type.infer_type_recursive(state, stack)?;
-                stack.pop();
-                let valid = if let Self::Identifier(s, _) = &inner_type_type {
-                    match &**s {
-                        "Type" => true,
-                        _ => {
-                            s.len() > 4
-                                && &s[..4] == "Type"
-                                && match s[4..].parse::<u64>() {
-                                    Ok(_) => true,
-                                    Err(_) => false,
-                                }
+                let valid = if let Self::Identifier(_, _) = inner_type {
+                    let inner_type_type = inner_type.infer_type_recursive(state, stack)?;
+                    if let Self::Identifier(s, _) = &inner_type_type {
+                        match &**s {
+                            "Type" => true,
+                            _ => {
+                                s.len() > 4
+                                    && &s[..4] == "Type"
+                                    && match s[4..].parse::<u64>() {
+                                        Ok(_) => true,
+                                        Err(_) => false,
+                                    }
+                            }
                         }
+                    } else {
+                        false
                     }
                 } else {
                     false
                 };
+                stack.pop();
                 if !valid {
                     return Err(KernelError::InvalidType {
                         incorrect_term: *value_term.clone(),

--- a/rooster_kernel/src/lib.rs
+++ b/rooster_kernel/src/lib.rs
@@ -832,7 +832,7 @@ impl Term {
             self.replace(name, &term.1);
         }
     }
-    
+
     pub fn delta_normalize_inner(self: &mut Self, state: &State, stack: &Vec<(String, Self)>) {
         for (name, term) in &state.terms {
             let mut replace = true;
@@ -1011,7 +1011,7 @@ impl Term {
         }
         self.alpha_normalize();
     }
-    
+
     pub fn full_normalize_inner(self: &mut Self, state: &State, stack: &Vec<(String, Self)>) {
         self.delta_normalize_inner(state, stack);
         loop {
@@ -1642,6 +1642,7 @@ impl Term {
                             parameter_term.infer_type_recursive(state, stack)?;
                         parameter_type.full_normalize_inner(state, stack);
                         let mut expected_parameter_type = binding_type.clone();
+                        expected_parameter_type.infer_type_recursive(state, stack)?;
                         expected_parameter_type.full_normalize_inner(state, stack);
                         let mut actual_function_term = function_term.clone();
                         let mut generic_identifier = "".to_string();
@@ -1887,6 +1888,7 @@ impl Term {
             } => {
                 binding_type.infer_type_recursive(state, stack)?;
                 let mut normalized_binding_type = binding_type.clone();
+                normalized_binding_type.infer_type_recursive(state, stack)?;
                 normalized_binding_type.full_normalize_inner(state, stack);
                 stack.push((binding_identifier.clone(), *normalized_binding_type.clone()));
                 let inner_type = value_term.infer_type_recursive(state, stack)?;
@@ -1995,10 +1997,13 @@ impl Term {
                 debug_context: _,
             } => {
                 let mut value_term_type = value_term.infer_type_recursive(state, stack)?;
+                value_term_type.infer_type_recursive(state, stack)?;
                 value_term_type.full_normalize_inner(state, stack);
                 let mut expanded_type_term = *type_term.clone();
+                expanded_type_term.infer_type_recursive(state, stack)?;
                 expanded_type_term.full_normalize_inner(state, stack);
                 expanded_type_term.fixed_point_reduce(true);
+                expanded_type_term.infer_type_recursive(state, stack)?;
                 expanded_type_term.full_normalize_inner(state, stack);
                 if value_term_type == expanded_type_term {
                     return Ok(*type_term.clone());

--- a/rooster_kernel/src/lib.rs
+++ b/rooster_kernel/src/lib.rs
@@ -655,7 +655,10 @@ impl Term {
                         loop {
                             let new_binding_identifier =
                                 format!("{}{}", binding_identifier, suffix);
-                            if !value_term.contains(&new_binding_identifier) {
+                            if !value_term.contains(&new_binding_identifier)
+                                && !value.contains(&new_binding_identifier)
+                                && &new_binding_identifier != identifier
+                            {
                                 value_term.replace(
                                     binding_identifier,
                                     &Self::Identifier(

--- a/rooster_kernel/tests/common/mod.rs
+++ b/rooster_kernel/tests/common/mod.rs
@@ -66,6 +66,19 @@ fn parse_term(input: &[char], try_application: bool) -> (Term, &[char]) {
                 rest_of_input,
             )
         }
+        '℺' => {
+            let (type_term, input2) = parse_term(&input[1..], true);
+            assert!(input2[0] == '.');
+            let (value_term, rest_of_input) = parse_term(&input2[1..], true);
+            (
+                Term::Constructor {
+                    type_term: Box::new(type_term),
+                    value_term: Box::new(value_term),
+                    debug_context: TermDebugContext::Ignore,
+                },
+                rest_of_input,
+            )
+        }
         '(' => {
             let (inner_term, input2) = parse_term(&input[1..], true);
             assert!(input2[0] == ')');

--- a/rooster_kernel/tests/inductive_tests.rs
+++ b/rooster_kernel/tests/inductive_tests.rs
@@ -2,28 +2,28 @@ mod common;
 
 #[test]
 fn nat() {
-    common::execute(&[("nat", "Set", "𝐘self:Set.∀T:? Set.∀_:T.∀_:∀_:self.T.T")]);
+    common::execute(&[("nat", "Set", "𝐘self:Set.∀R:Type.∀T:R.∀_:T.∀_:∀_:self.T.T")]);
 }
 
 #[test]
 fn nat_constructors() {
     common::execute(&[
-        ("nat", "Set", "𝐘self:Set.∀T:? Set.∀_:T.∀_:∀_:self.T.T"),
-        ("O", "nat", "λT:? nat.λa:T.λb:∀_:nat.T.a"),
-        ("S", "∀_:nat.nat", "λx:nat.λT:? nat.λa:T.λb:∀_:nat.T.b x"),
+        ("nat", "Set", "𝐘self:Set.∀R:Type.∀T:R.∀_:T.∀_:∀_:self.T.T"),
+        ("O", "nat", "℺nat.λR:Type.λT:R.λa:T.λb:∀_:nat.T.a"),
+        ("S", "∀_:nat.nat", "λx:nat.℺nat.λR:Type.λT:R.λa:T.λb:∀_:nat.T.b x"),
     ]);
 }
 
 #[test]
 fn add() {
     common::execute(&[
-        ("nat", "Set", "𝐘self:Set.∀T:? Set.∀_:T.∀_:∀_:self.T.T"),
-        ("O", "nat", "λT:? nat.λa:T.λb:∀_:nat.T.a"),
-        ("S", "∀_:nat.nat", "λx:nat.λT:? nat.λa:T.λb:∀_:nat.T.b x"),
+        ("nat", "Set", "𝐘self:Set.∀R:Type.∀T:R.∀_:T.∀_:∀_:self.T.T"),
+        ("O", "nat", "℺nat.λR:Type.λT:R.λa:T.λb:∀_:nat.T.a"),
+        ("S", "∀_:nat.nat", "λx:nat.℺nat.λR:Type.λT:R.λa:T.λb:∀_:nat.T.b x"),
         (
             "add",
             "∀_:nat.∀_:nat.nat",
-            "𝐘self:(∀_:nat.∀_:nat.nat).λn:nat.λm:nat.n (nat) m (λp:(nat).S (self p m))",
+            "𝐘self:(∀_:nat.∀_:nat.nat).λn:nat.λm:nat.n Set (nat) m (λp:(nat).S (self p m))",
         ),
     ]);
 }
@@ -31,13 +31,13 @@ fn add() {
 #[test]
 fn nat_induction() {
     common::execute(&[
-        ("nat", "Set", "𝐘self:Set.∀T:? Set.∀_:T.∀_:∀_:self.T.T"),
-        ("O", "nat", "λT:? nat.λa:T.λb:∀_:nat.T.a"),
-        ("S", "∀_:nat.nat", "λx:nat.λT:? nat.λa:T.λb:∀_:nat.T.b x"),
+        ("nat", "Set", "𝐘self:Set.∀R:Type.∀T:R.∀_:T.∀_:∀_:self.T.T"),
+        ("O", "nat", "℺nat.λR:Type.λT:R.λa:T.λb:∀_:nat.T.a"),
+        ("S", "∀_:nat.nat", "λx:nat.℺nat.λR:Type.λT:R.λa:T.λb:∀_:nat.T.b x"),
         (
             "nat_induction",
             "∀P:∀_:nat.Prop.∀_:P O.∀_:∀n:nat.∀_:P n.P (S n).∀n:nat.P n",
-            "𝐘self:∀P:∀_:nat.Prop.∀_:P O.∀_:∀n:nat.∀_:P n.P (S n).∀n:nat.P n.λP:∀_:nat.Prop.λpO:P O.λh:∀n:nat.∀_:P n.P (S n).λn:nat.n (P n) pO (λp:nat.h p (self P pO h p))",
+            "𝐘self:∀P:∀_:nat.Prop.∀_:P O.∀_:∀n:nat.∀_:P n.P (S n).∀n:nat.P n.λP:∀_:nat.Prop.λpO:P O.λh:∀n:nat.∀_:P n.P (S n).λn:nat.n Prop (P n) pO (λp:nat.h p (self P pO h p))",
         ),
     ]);
 }

--- a/rooster_kernel/tests/inductive_tests.rs
+++ b/rooster_kernel/tests/inductive_tests.rs
@@ -10,7 +10,11 @@ fn nat_constructors() {
     common::execute(&[
         ("nat", "Set", "𝐘self:Set.∀R:Type.∀T:R.∀_:T.∀_:∀_:self.T.T"),
         ("O", "nat", "℺nat.λR:Type.λT:R.λa:T.λb:∀_:nat.T.a"),
-        ("S", "∀_:nat.nat", "λx:nat.℺nat.λR:Type.λT:R.λa:T.λb:∀_:nat.T.b x"),
+        (
+            "S",
+            "∀_:nat.nat",
+            "λx:nat.℺nat.λR:Type.λT:R.λa:T.λb:∀_:nat.T.b x",
+        ),
     ]);
 }
 
@@ -19,7 +23,11 @@ fn add() {
     common::execute(&[
         ("nat", "Set", "𝐘self:Set.∀R:Type.∀T:R.∀_:T.∀_:∀_:self.T.T"),
         ("O", "nat", "℺nat.λR:Type.λT:R.λa:T.λb:∀_:nat.T.a"),
-        ("S", "∀_:nat.nat", "λx:nat.℺nat.λR:Type.λT:R.λa:T.λb:∀_:nat.T.b x"),
+        (
+            "S",
+            "∀_:nat.nat",
+            "λx:nat.℺nat.λR:Type.λT:R.λa:T.λb:∀_:nat.T.b x",
+        ),
         (
             "add",
             "∀_:nat.∀_:nat.nat",

--- a/test.roo
+++ b/test.roo
@@ -1,6 +1,6 @@
 /* This is an example file to test rcoc */
 
-/*// basic syntax
+// basic syntax
 let implication_is_reflexive:
     @(T: Prop, x: T) T
 =
@@ -78,17 +78,17 @@ let equivalence_implies_implication:
     |h: {A -> B} /\ {B -> A}|
     |a: A|
     conjunction_implies_operand(A -> B, B -> A, h, a)
-;*/
+;
 
 // inductive types
-let nat: Set = recursive(self: Set) @(T: ?(Set)) T -> {self -> T} -> T;
+let nat: Set = recursive(self: Set) @(R: Type, T: R) T -> {self -> T} -> T;
 
-let O: nat = |T: ?(nat), a: T, b: nat -> T| a;
-let S: nat -> nat = |x: nat| |T: ?(nat), a: T, b: nat -> T| b(x);
+let O: nat = constructor(nat) |R: Type, T: R, a: T, b: nat -> T| a;
+let S: nat -> nat = |x: nat| constructor(nat) |R: Type, T: R, a: T, b: nat -> T| b(x);
 
-/*let add: nat -> nat -> nat = recursive(self: nat -> nat -> nat) |n, m: nat| n(
-    nat, m, |p: nat| S(self(p, m))
-);*/
+let add: nat -> nat -> nat = recursive(self: nat -> nat -> nat) |n, m: nat| n(
+    Set, nat, m, |p: nat| S(self(p, m))
+);
 
 let nat_induction: @(P: nat -> Prop)
     P(O) -> {@(n: nat) P(n) -> P(S(n))} -> @(n: nat) P(n)
@@ -99,5 +99,5 @@ let nat_induction: @(P: nat -> Prop)
     |pO: P(O)|
     |h: @(n: nat) P(n) -> P(S(n))|
     |n: nat|
-    n(P(n), pO, |p: nat| h(p, self(P, pO, h, p)))
+    n(Prop, P(n), pO, |p: nat| h(p, self(P, pO, h, p)))
 ;


### PR DESCRIPTION
This branch contains a redesign of inductive types within Rooster's kernel. The redesign focuses on legalizing two specific constructs in the core language:

* `@(R: Type, T: R) ...`
* `constructor(...) ...`

The first pattern, illegal in vanilla CoC, will be used to introduce inductive types, and its corresponding member lambda, for constructors. Whenever these patterns are detected, the appropriate inductive type validity check will be performed, to keep the logic consistent.

The second pattern will be used within constructors, as a helper for the kernel to be able to "undo" recursion during match patterns.

I believe this solution is more elegant than the original, which will be removed from the kernel.