### PR TITLE
Add support for fuzzing with afl.rs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ target/
 Cargo.lock
 **/*.rs.bk
 *.pdb
+rooster_afl/in
+rooster_afl/out
 rooster_kernel/fuzz/artifacts
 rooster_kernel/fuzz/corpus
 rooster_kernel/fuzz/coverage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["rooster", "rooster_kernel"]
+members = ["rooster", "rooster_afl", "rooster_kernel"]
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["rooster", "rooster_afl", "rooster_kernel"]
+default-members = ["rooster", "rooster_kernel"]
 
 [profile.release]
 opt-level = 3

--- a/rooster_afl/Cargo.toml
+++ b/rooster_afl/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rooster_afl"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rooster_kernel = {path = "../rooster_kernel"}
+afl = "0.13"

--- a/rooster_afl/src/main.rs
+++ b/rooster_afl/src/main.rs
@@ -1,0 +1,188 @@
+#[macro_use]
+extern crate afl;
+use rooster_kernel::*;
+
+fn generate_term(data: &[u8]) -> (Option<Term>, &[u8]) {
+    if data.len() <= 0 {
+        return (None, data);
+    }
+    match data[0] {
+        0..=63 => (
+            Some(Term::Identifier(
+                format!("x{}", data[0] % 4),
+                TermDebugContext::Ignore,
+            )),
+            &data[1..],
+        ),
+        64..=127 => (
+            Some(Term::Identifier(
+                ["Prop", "Set", "Type"][(data[0] % 3) as usize].to_string(),
+                TermDebugContext::Ignore,
+            )),
+            &data[1..],
+        ),
+        128..=159 => {
+            let (function_term_option, data2) = generate_term(&data[1..]);
+            let (parameter_term_option, data3) = generate_term(data2);
+            let function_term = match function_term_option {
+                Some(x) => x,
+                None => return (generate_term(&vec![data[0] - 128]).0, &data[data.len()..]),
+            };
+            let parameter_term = match parameter_term_option {
+                Some(x) => x,
+                None => return (generate_term(&vec![data[0] - 128]).0, &data[data.len()..]),
+            };
+            (
+                Some(Term::Application {
+                    function_term: Box::new(function_term),
+                    parameter_term: Box::new(parameter_term),
+                    debug_context: TermDebugContext::Ignore,
+                }),
+                data3,
+            )
+        }
+        160..=191 => {
+            let identifier = format!("x{}", data[0] % 4);
+            let (type_term_option, data2) = generate_term(&data[1..]);
+            let (value_term_option, data3) = generate_term(data2);
+            let type_term = match type_term_option {
+                Some(x) => x,
+                None => return (generate_term(&vec![data[0] - 128]).0, &data[data.len()..]),
+            };
+            let value_term = match value_term_option {
+                Some(x) => x,
+                None => return (generate_term(&vec![data[0] - 128]).0, &data[data.len()..]),
+            };
+            (
+                Some(Term::Lambda {
+                    binding_identifier: identifier,
+                    binding_type: Box::new(type_term),
+                    value_term: Box::new(value_term),
+                    debug_context: TermDebugContext::Ignore,
+                }),
+                data3,
+            )
+        }
+        192..=223 => {
+            let identifier = format!("x{}", data[0] % 4);
+            let (type_term_option, data2) = generate_term(&data[1..]);
+            let (value_term_option, data3) = generate_term(data2);
+            let type_term = match type_term_option {
+                Some(x) => x,
+                None => return (generate_term(&vec![data[0] - 128]).0, &data[data.len()..]),
+            };
+            let value_term = match value_term_option {
+                Some(x) => x,
+                None => return (generate_term(&vec![data[0] - 128]).0, &data[data.len()..]),
+            };
+            (
+                Some(Term::Forall {
+                    binding_identifier: identifier,
+                    binding_type: Box::new(type_term),
+                    value_term: Box::new(value_term),
+                    debug_context: TermDebugContext::Ignore,
+                }),
+                data3,
+            )
+        }
+        224..=239 => {
+            let identifier = format!("x{}", data[0] % 4);
+            let (type_term_option, data2) = generate_term(&data[1..]);
+            let (value_term_option, data3) = generate_term(data2);
+            let type_term = match type_term_option {
+                Some(x) => x,
+                None => return (generate_term(&vec![data[0] - 128]).0, &data[data.len()..]),
+            };
+            let value_term = match value_term_option {
+                Some(x) => x,
+                None => return (generate_term(&vec![data[0] - 128]).0, &data[data.len()..]),
+            };
+            (
+                Some(Term::FixedPoint {
+                    binding_identifier: identifier,
+                    binding_type: Box::new(type_term),
+                    value_term: Box::new(value_term),
+                    debug_context: TermDebugContext::Ignore,
+                }),
+                data3,
+            )
+        }
+        240..=255 => {
+            let (type_term_option, data2) = generate_term(&data[1..]);
+            let (value_term_option, data3) = generate_term(data2);
+            let type_term = match type_term_option {
+                Some(x) => x,
+                None => return (generate_term(&vec![data[0] - 128]).0, &data[data.len()..]),
+            };
+            let value_term = match value_term_option {
+                Some(x) => x,
+                None => return (generate_term(&vec![data[0] - 128]).0, &data[data.len()..]),
+            };
+            (
+                Some(Term::Constructor {
+                    type_term: Box::new(type_term),
+                    value_term: Box::new(value_term),
+                    debug_context: TermDebugContext::Ignore,
+                }),
+                data3,
+            )
+        }
+    }
+}
+
+fn generate_definition<'a, 'b>(
+    data: &'a [u8],
+    state: &'b State,
+) -> Result<((Term, Term), &'a [u8]), KernelError> {
+    let (value_term_option, remaining_data) = generate_term(data);
+    let value_term = value_term_option.unwrap();
+    //println!("value_term: {:?}", value_term); //D
+    let type_term = value_term.infer_type(state)?;
+    return Ok(((type_term, value_term), remaining_data));
+}
+
+fn main() {
+    fuzz!(|data: &[u8]| {
+        let mut state = State::new();
+        //let stat = vec![];
+        let mut definitions = vec![];
+        let mut remaining_data = &*data;
+        let mut index = 0;
+        let mut r#false = Term::Forall {
+            binding_identifier: "P".to_string(),
+            binding_type: Box::new(Term::Identifier(
+                "Prop".to_string(),
+                TermDebugContext::Ignore,
+            )),
+            value_term: Box::new(Term::Identifier("P".to_string(), TermDebugContext::Ignore)),
+            debug_context: TermDebugContext::Ignore,
+        };
+        r#false.full_normalize(&state);
+        loop {
+            if remaining_data.len() <= 0 {
+                break;
+            }
+            let (definition, new_remaining_data) = match generate_definition(remaining_data, &state)
+            {
+                Ok(x) => x,
+                Err(_) => return,
+            };
+            remaining_data = new_remaining_data;
+            let identifier = format!("x{}", index);
+            let (definition_type, definition_value) = (definition.0.clone(), definition.1.clone());
+            let mut normalized_type = definition.0.clone();
+            //println!("{} = {:?}\n\t:{:?}", identifier, definition_value, definition_type); //D
+            match state.try_define(&identifier, definition.0, definition.1) {
+                Ok(_) => (),
+                Err(_) => return,
+            };
+            definitions.push((identifier, definition_type, definition_value));
+            normalized_type.full_normalize(&state);
+            if normalized_type == r#false {
+                println!("{:?}", definitions);
+                panic!("CRITICAL ERROR: INCONSISTENT LOGIC");
+            }
+            index += 1;
+        }
+    });
+}


### PR DESCRIPTION
This should complement libFuzzer with a different fuzzer that also [tends to perform better](https://www.fuzzbench.com/reports/index.html). The target workflow would be:

    cd rooster_kernel
    rm fuzz/corpus/default/* # To remove files from previous executions
    cargo fuzz run -j 12 default -- -max_len=32 -rss_limit_mb=14000 # On my machine
    # After some fuzzing, if all goes well
    cd ../rooster_afl
    mkdir in out # If not already present
    rm -r in/* out/* # To remove files from previous executions
    cp ../rooster_kernel/fuzz/corpus/default/* in/
    cargo afl build
    cargo afl fuzz -G 256 -i in -o out -M fuzzer0 ../target/debug/rooster_afl
    # And as many parallel fuzzers as desired, each on a different terminal instance
    cargo afl fuzz -G 256 -i in -o out -S fuzzer1 ../target/debug/rooster_afl
    cargo afl fuzz -G 256 -i in -o out -S fuzzer2 ../target/debug/rooster_afl
    cargo afl fuzz -G 256 -i in -o out -S fuzzer3 ../target/debug/rooster_afl

I'll do a bit of fuzzing before merging this.